### PR TITLE
Updating Godot

### DIFF
--- a/apps/Godot/install
+++ b/apps/Godot/install
@@ -2,15 +2,15 @@
 rm -rf ~/Godot
 mkdir -p ~/Godot
 cd ~/Godot
-wget -O ~/Godot/godot.zip https://github.com/hiulit/Unofficial-Godot-Engine-Raspberry-Pi/releases/download/v1.7.0/godot_3.4-stable_rpi4.zip || error "failed to download!"
+wget -O ~/Godot/godot.zip https://github.com/hiulit/Unofficial-Godot-Engine-Raspberry-Pi/releases/download/v1.9.0/godot_3.4.2-stable_rpi4.zip || error "failed to download!"
 unzip $(pwd)/godot.zip
 rm -f $(pwd)/godot.zip
-rm -f godot_3.4-stable_rpi4_headless_lto.bin
-rm -f godot_3.4-stable_rpi4_server_lto.bin
+rm -f godot_3.4.2-stable_rpi4_headless_lto.bin
+rm -f godot_3.4.2-stable_rpi4_server_lto.bin
 echo "[Desktop Entry]
 Name=Godot Engine
 Comment=Best Opensource Game Engine 
-Exec=bash -c 'cd $HOME/Godot ; MESA_GL_VERSION_OVERRIDE=3.3 $HOME/Godot/godot_3.4-stable_rpi4_editor_lto.bin'
+Exec=bash -c 'cd $HOME/Godot ; MESA_GL_VERSION_OVERRIDE=3.3 $HOME/Godot/godot_3.4.2-stable_rpi4_editor_lto.bin'
 Icon=$(dirname $0)/icon-64.png
 Terminal=false
 Type=Application


### PR DESCRIPTION
Godot 3.4.2 and 1.9.0 RPI port version
[Jumped directly from 1.7.0 to 1.9.0 since I forgot to update the 1.8.0]